### PR TITLE
Update en_us.json for Mahj CtE [Dissonance] next update

### DIFF
--- a/src/main/resources/assets/calemiutils/lang/en_us.json
+++ b/src/main/resources/assets/calemiutils/lang/en_us.json
@@ -46,6 +46,7 @@
 
   "itemGroup.calemiutils.tabMain": "Calemi's Utils",
   "enchantment.calemiutils.crushing": "Crushing",
+  "enchantment.calemiutils.crushing.desc": "Increases the range of the Sledgehammer charge ability.",
 
   "curios.identifier.wallet" : "Wallet"
 }


### PR DESCRIPTION
I added an enchantment description line for crushing enchantment so that it works with Enchantment Descriptions mod for Mahj's Craft to Exile [Dissonance] next update. 

I will send a copy to Mahj in case if the next update of the mod doesn't line up with next pack update for CtE [Dissonance].